### PR TITLE
Add hyprbazzite-nvidia-open variant

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,10 @@ jobs:
             image_alias: ""
             base_image: "ghcr.io/ublue-os/bazzite:latest"
             image_desc: "HyprBazzite Custom Image with open video drivers, based on bazzite"
+          - image_name: "hyprbazzite-nvidia-open"
+            image_alias: ""
+            base_image: "ghcr.io/ublue-os/bazzite-nvidia-open:latest"
+            image_desc: "HyprBazzite Custom Image with NVIDIA open drivers, based on bazzite-nvidia-open"
 
     permissions:
       contents: read

--- a/Justfile
+++ b/Justfile
@@ -22,15 +22,21 @@ build-open-video $tag=default_tag:
 build-bazzite-open-video $tag=default_tag:
     just build "hyprbazzite-open-video" "{{ tag }}" "ghcr.io/ublue-os/bazzite:latest"
 
+# Build the HyprBazzite NVIDIA open drivers variant (based on bazzite-nvidia-open)
+[group('Build Image')]
+build-bazzite-nvidia-open $tag=default_tag:
+    just build "hyprbazzite-nvidia-open" "{{ tag }}" "ghcr.io/ublue-os/bazzite-nvidia-open:latest"
+
 # Build all HyprBlue variants
 [group('Build Image')]
 build-all-hyprblue $tag=default_tag:
     just build-open-video "{{ tag }}"
 
-# Build all HyprBazzite variants
+# Build all HyprBazzite variants (open-video + nvidia-open)
 [group('Build Image')]
 build-all-bazzite $tag=default_tag:
     just build-bazzite-open-video "{{ tag }}"
+    just build-bazzite-nvidia-open "{{ tag }}"
 
 # Build all variants (HyprBlue + HyprBazzite)
 [group('Build Image')]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ All images are available at `ghcr.io/ashebanow/`:
 
 ### HyprBazzite (Based on Bazzite)
 - **`hyprbazzite-open-video`** - Open source video drivers (based on `bazzite:latest`)
+- **`hyprbazzite-nvidia-open`** - NVIDIA open kernel modules (based on `bazzite-nvidia-open:latest`)
 
 ## Important Notes
 
@@ -42,7 +43,8 @@ These packages will be added back when the COPR maintainer rebuilds them against
 
 Install either Bluefin or Bazzite from ISO:
 - For HyprBlue: Install bluefin-dx
-- For HyprBazzite: Install bazzite
+- For HyprBazzite (open video): Install bazzite
+- For HyprBazzite (NVIDIA): Install bazzite-nvidia-open
 
 Set up LUKS/TPM/Secure Boot as needed during installation.
 
@@ -54,8 +56,11 @@ Choose the appropriate variant for your system:
 # HyprBlue (Bluefin-based):
 sudo bootc switch ghcr.io/ashebanow/hyprblue-open-video
 
-# HyprBazzite (Bazzite-based):
+# HyprBazzite (Bazzite-based, open video drivers):
 sudo bootc switch ghcr.io/ashebanow/hyprbazzite-open-video
+
+# HyprBazzite (Bazzite-based, NVIDIA open drivers):
+sudo bootc switch ghcr.io/ashebanow/hyprbazzite-nvidia-open
 
 # Alias (points to hyprblue-open-video):
 sudo bootc switch ghcr.io/ashebanow/hyprblue


### PR DESCRIPTION
## Summary

Re-adds NVIDIA support using NVIDIA's open kernel modules (`nvidia-open`) instead of the deprecated proprietary drivers. This uses Universal Blue's `bazzite-nvidia-open` base image which provides NVIDIA's recommended driver stack for Turing and newer GPUs (RTX 20/30/40 series).

### Background

NVIDIA transitioned to open-source GPU kernel modules starting with the R560 driver release (July 2024). The proprietary driver variants were removed from Bluefin/Bazzite upstream, but the `nvidia-open` variants remain actively maintained and are NVIDIA's recommended approach for modern GPUs.

From [NVIDIA's official announcement](https://developer.nvidia.com/blog/nvidia-transitions-fully-towards-open-source-gpu-kernel-modules/):

> *"NVIDIA is now transitioning fully to open-source GPU kernel modules... For different different GPU product types, the default installation is changing: For GeForce and Workstation GPUs, the open-source GPU kernel modules are the default for installer packages starting with the R560 release on systems running the Linux kernel version 6.6 or newer."*

### Changes

- Added `hyprbazzite-nvidia-open` to the GitHub Actions build matrix
- Added `build-bazzite-nvidia-open` recipe to Justfile
- Updated `build-all-bazzite` to include the new variant
- Updated README.md with installation instructions

### Features Provided by nvidia-open

Unlike NVK/nouveau (used in open-video variants), the nvidia-open driver provides:
- Ray tracing support
- DLSS
- NVENC video encoding
- Full CUDA support
- Equivalent performance to the proprietary driver

From the [NVIDIA Open GPU Kernel Modules README](https://github.com/NVIDIA/open-gpu-kernel-modules#compatible-gpus):

> *"For different GPU architectures, the capabilities and support level of the open-source GPU kernel modules varies... For Turing, Ampere, Ada Lovelace, or Hopper and later: Different feature sets are supported. On these GPUs, all features of the driver are supported, including compute acceleration, graphics hardware acceleration, and video decoding/encoding acceleration."*

### Supported Hardware

Per [NVIDIA documentation](https://developer.nvidia.com/blog/nvidia-transitions-fully-towards-open-source-gpu-kernel-modules/), `nvidia-open` is recommended for:
- Turing (RTX 20 series)
- Ampere (RTX 30 series)  
- Ada Lovelace (RTX 40 series)
- Hopper and newer

> *"NVIDIA recommends transitioning to the open-source GPU kernel modules for the following product lines: NVIDIA Turing, NVIDIA Ampere, NVIDIA Ada Lovelace, NVIDIA Hopper, and later GPU architectures."*

### References

1. [NVIDIA Transitions Fully Towards Open-Source GPU Kernel Modules](https://developer.nvidia.com/blog/nvidia-transitions-fully-towards-open-source-gpu-kernel-modules/) - NVIDIA Technical Blog, July 2024
2. [NVIDIA Open GPU Kernel Modules](https://github.com/NVIDIA/open-gpu-kernel-modules) - Official GitHub Repository

## Test plan

- [ ] Verify GitHub Actions build succeeds for the new variant
- [ ] Test `just build-bazzite-nvidia-open` locally
- [ ] Verify image boots and Hyprland/Niri function correctly with NVIDIA hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)