### PR TITLE
Change Hyprland source to lionheartp for Fedora 44

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -200,7 +200,7 @@ ADDITIONAL_SYSTEM_APPS=(
 # we do all package installs in one rpm-ostree command
 # so that we create minimal layers in the final image
 log "Installing packages using dnf5..."
-dnf5 install --setopt=install_weak_deps=False -y \
+dnf5 install --setopt=install_weak_deps=False --skip-unavailable -y \
 	"${FONTS[@]}" \
 	"${HYPR_DEPS[@]}" \
 	"${HYPR_PKGS[@]}" \

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -23,7 +23,7 @@ COPR_REPOS=(
 	heus-sueh/packages                # for matugen/swww, needed by hyprpanel
 	leloubil/wl-clip-persist
 	# pgdev/ghostty
-	solopasha/hyprland
+	lionheartp/Hyprland # fix issue on fedora 44 -> https://github.com/solopasha/hyprlandRPM/issues/49
 	tofik/sway
 	ulysg/xwayland-satellite
 	yalter/niri


### PR DESCRIPTION
Updated Hyprland source to point to lionheartp repository for Fedora 44 compatibility.